### PR TITLE
feat: add root_marker input to support --root-marker flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20.3-bullseye
 
-ENV VERSION=v0.3.9
+ENV VERSION=v0.3.10
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Specify directories to pass changed-objects command'
     required: false
     default: ''
+  root_marker:
+    description: 'A glob pattern of file that marks the root directory (e.g. *.tf). When specified, traverses parent directories to find the nearest ancestor containing a matching file.'
+    required: false
+    default: ''
 outputs:
   changes:
     description: 'Changed objects'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,10 @@ if [[ -n ${INPUT_DIR_EXIST} ]]; then
   flags+=("--dir-exist=${INPUT_DIR_EXIST}")
 fi
 
+if [[ -n ${INPUT_ROOT_MARKER} ]]; then
+  flags+=("--root-marker=${INPUT_ROOT_MARKER}")
+fi
+
 if [[ -n ${INPUT_IGNORE} ]]; then
   for ig in ${INPUT_IGNORE//$'\n'/ }
   do


### PR DESCRIPTION
## What

Add a new optional `root_marker` input that passes `--root-marker` to the `changed-objects` CLI.

- Add `root_marker` input to `action.yml` (optional, default empty)
- Add `INPUT_ROOT_MARKER` handling in `entrypoint.sh`

## Why

To expose the `--root-marker` option added in `changed-objects` through the GitHub Actions wrapper, allowing workflows to specify a file pattern (e.g. `*.tf`) that marks the root of a module directory. This enables Terraform workflows to resolve non-`.tf` file changes to the correct module root without custom shell logic.