### PR TITLE
Pin third-party actions to SHA and harden workflows

### DIFF
--- a/.ghalint.yaml
+++ b/.ghalint.yaml
@@ -1,0 +1,6 @@
+excludes:
+  # tagpr needs git credentials to push tags and create releases
+  - policy_name: checkout_persist_credentials_should_be_false
+    workflow_file_path: .github/workflows/release.yaml
+    job_name: tagpr
+    step_name: Checkout

--- a/.github/workflows/add_labels.yaml
+++ b/.github/workflows/add_labels.yaml
@@ -11,8 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           sync-labels: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,9 +17,9 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run tagpr
-        uses: Songmu/tagpr@3dca11e7c0d68637ee212ddd35acc3d30a7403a4 # v1.5.0
+        uses: Songmu/tagpr@9d0f650553240dab1fa907eca27e3fd5b586e538 # v1.18.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: run-tagpr

--- a/.github/workflows/sync_labels.yaml
+++ b/.github/workflows/sync_labels.yaml
@@ -18,9 +18,11 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Sync labels
-        uses: EndBug/label-sync@v2
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/labels.yaml


### PR DESCRIPTION
## Summary
Pin all third-party GitHub Actions to full-length commit SHAs and update them to the latest stable versions. Add `persist-credentials: false` to checkout steps that don't require git credentials. Add `.ghalint.yaml` to exclude the tagpr job which needs credentials for pushing.

## Background
Unpinned actions using only version tags (e.g. `@v3`, `@v5`) are vulnerable to supply chain attacks — a compromised tag can silently point to malicious code. SHA pinning ensures that the exact reviewed commit is used. Additionally, `persist-credentials: false` prevents unintended use of the GITHUB_TOKEN after checkout, reducing the blast radius if a subsequent step is compromised.

## Changes
- **SHA pinning & version updates** (via `pinact -u` with 7-day cooldown):
  - `actions/checkout`: v3/v4 → `v6.0.2` (SHA pinned)
  - `actions/labeler`: v5 → `v6.0.1` (SHA pinned)
  - `Songmu/tagpr`: v1.5.0 → `v1.18.1` (SHA pinned; v1.18.2/v1.18.3 skipped due to cooldown)
  - `EndBug/label-sync`: v2 → `v2.3.3` (SHA pinned)
- **`persist-credentials: false`** added to `add_labels.yaml` and `sync_labels.yaml`
- **`.ghalint.yaml`** created to exclude `release.yaml`'s tagpr job from the persist-credentials policy (tagpr needs credentials to push tags)