### PR TITLE
chore: bump changed-objects to v0.3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20.3-bullseye
 
-ENV VERSION=v0.3.10
+ENV VERSION=v0.3.11
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \


### PR DESCRIPTION
## Summary
Bump `changed-objects` CLI version from v0.3.10 to v0.3.11 in the Dockerfile.